### PR TITLE
docs: rename "Send Checks" to "Send Links"

### DIFF
--- a/docs/features/send-checks.mdx
+++ b/docs/features/send-checks.mdx
@@ -1,41 +1,41 @@
 ---
 id: send-checks
-title: Send Checks
+title: Send Links
 ---
 
-# Send Checks
+# Send Links
 
 Send crypto to anyone using a shareable link — no wallet address needed.
 
 ## Overview
 
-Send Checks lets you send cryptocurrency to anyone by creating a shareable claim link. Recipients don't need to know your wallet address, and you don't need theirs. Simply create a check, share the link, and the recipient can claim the funds by registering or signing into Send.
+Send Links lets you send cryptocurrency to anyone by creating a shareable claim link. Recipients don't need to know your wallet address, and you don't need theirs. Simply create a link, share it, and the recipient can claim the funds by registering or signing into Send.
 
 ## How It Works
 
 ### For Senders
 
-1. **Create a Check**
-   - Tap "Send Check" from the send screen
+1. **Create a Link**
+   - Tap "Send Link" from the send screen
    - Choose the token and enter the amount you want to send
-   - Set an expiration date for the check
+   - Set an expiration date for the link
    - Optionally add a note for the recipient
    - Confirm and sign the transaction
 
 2. **Share the Link**
    - After creation, you'll receive a unique claim URL
-   - **Important:** Save this link before leaving — if lost, you'll need to cancel the check to recover funds
+   - **Important:** Save this link before leaving — if lost, you'll need to cancel the link to recover funds
    - Share the link via text, email, or any messaging app
 
-3. **Manage Your Checks**
-   - View all sent checks in the "Manage Checks" screen
-   - See check status: Pending, Claimed, Expired, or Canceled
-   - Cancel unclaimed checks to recover your funds
+3. **Manage Your Links**
+   - View all sent links in the "Manage Links" screen
+   - See link status: Pending, Claimed, Expired, or Canceled
+   - Cancel unclaimed links to recover your funds
 
 ### For Recipients
 
 1. **Receive a Link**
-   - Someone shares a Send Check link with you
+   - Someone shares a Send Link with you
 
 2. **Claim Your Funds**
    - Open the link in your browser
@@ -48,54 +48,54 @@ Send Checks lets you send cryptocurrency to anyone by creating a shareable claim
 ## Key Features
 
 ### Multi-Token Support
-- Send up to 5 different tokens in a single check
+- Send up to 5 different tokens in a single link
 - Supports USDC, SEND, and other supported tokens
 
 ### Expiration Dates
-- Set custom expiration times for your checks
-- Expired unclaimed checks can be reclaimed by the sender
+- Set custom expiration times for your links
+- Expired unclaimed links can be reclaimed by the sender
 
 ### Personal Notes
-- Add a message to your check
+- Add a message to your link
 - Recipients see your note when claiming
 
 ### Activity History
-- Track all sent and received checks
+- Track all sent and received links
 - View claim status, timestamps, and transaction details
 
-## Check States
+## Link States
 
 | Status | Description |
 |--------|-------------|
-| **Pending** | Active check waiting to be claimed |
+| **Pending** | Active link waiting to be claimed |
 | **Claimed** | Successfully claimed by recipient |
 | **Expired** | Past expiration date, unclaimed |
 | **Canceled** | Sender reclaimed the funds |
 
 ## Security
 
-- **Link Security:** Only share check links with your intended recipient — anyone with the link can claim the funds
-- **Expiration Protection:** Unclaimed checks can be canceled to recover funds
-- **On-Chain Security:** All checks are secured by smart contracts on Base
+- **Link Security:** Only share links with your intended recipient — anyone with the link can claim the funds
+- **Expiration Protection:** Unclaimed links can be canceled to recover funds
+- **On-Chain Security:** All links are secured by smart contracts on Base
 
 ## Fees
 
-- Small USDC fee for creating and canceling checks
-- Claiming checks is gas-sponsored (free for recipients)
+- Small USDC fee for creating and canceling links
+- Claiming links is gas-sponsored (free for recipients)
 
 ## FAQ
 
 **Q: What happens if I lose the claim link?**
-A: You can cancel the check from the "Manage Checks" screen to recover your funds, then create a new check.
+A: You can cancel the link from the "Manage Links" screen to recover your funds, then create a new link.
 
-**Q: Can I send a check to someone without a Send account?**
+**Q: Can I send a link to someone without a Send account?**
 A: Yes! They can register for a Send account when they open the claim link.
 
-**Q: How long do checks last?**
-A: You set the expiration when creating the check. After expiration, you can reclaim the funds.
+**Q: How long do links last?**
+A: You set the expiration when creating the link. After expiration, you can reclaim the funds.
 
-**Q: Can I cancel a check after sending?**
-A: Yes, you can cancel any unclaimed check from the "Manage Checks" screen. A small fee applies.
+**Q: Can I cancel a link after sending?**
+A: Yes, you can cancel any unclaimed link from the "Manage Links" screen. A small fee applies.
 
-**Q: What tokens can I send via Check?**
+**Q: What tokens can I send via Send Link?**
 A: You can send any supported token on Send, including USDC and SEND.

--- a/docs/miscellaneous/send-contract-addresses.mdx
+++ b/docs/miscellaneous/send-contract-addresses.mdx
@@ -10,7 +10,7 @@ title: Send Contract Addresses
 | Send Token v1 | [`0xEab49138BA2Ea6dd776220fE26b7b8E446638956`](https://basescan.org/token/0xeab49138ba2ea6dd776220fe26b7b8e446638956) | ERC-20 token for the Send ecosystem ($SEND) |
 | Send Account Factory | [`0x008c9561857b6555584d20aC55110335759Aa2c2`](https://basescan.org/address/0x008c9561857b6555584d20ac55110335759aa2c2) | This factory contract is responsible for creating Send accounts on-chain |
 | Sendtag Checkout | [`0x36f43082d01df4801AF2D95aeEd1a0200C5510AE`](https://basescan.org/address/0x36f43082d01df4801af2d95aeEd1a0200c5510ae) | Handles Sendtag confirmations and affiliate bonuses on-chain |
-| Send Checks | [`0x274B45D75d71b7F627c00d87757B493E7E1312a7`](https://basescan.org/address/0x274B45D75d71b7F627c00d87757B493E7E1312a7) | Escrow contract for shareable payment links, allowing sending to any recipient |
+| Send Links | [`0x274B45D75d71b7F627c00d87757B493E7E1312a7`](https://basescan.org/address/0x274B45D75d71b7F627c00d87757B493E7E1312a7) | Escrow contract for shareable payment links, allowing sending to any recipient |
 | Send USDC Paymaster | [`0x592e1224D203Be4214B15e205F6081FbbaCFcD2D`](https://basescan.org/address/0x592e1224d203be4214b15e205f6081fbbacfcd2d) | Pays for Send account transactions in $USDC |
 | Send Merkle Drop | [`0xB9310daE45E71c7a160A13D64204623071a8E347`](https://basescan.org/address/0xb9310dae45e71c7a160a13d64204623071a8e347) | $SEND token airdrop contract for rewarding Send users |
 | Send Verifier | [`0xE269194e41Cd50E2986f82Fc23A2B95D8bAFED2B`](https://basescan.org/address/0xe269194e41cd50e2986f82fc23a2b95d8bafed2b) | Verifies each Send account transaction contains a valid signature |

--- a/docs/send-mobile-apps/features.mdx
+++ b/docs/send-mobile-apps/features.mdx
@@ -12,7 +12,7 @@ The Send mobile experience bundles core money tools and social trust layers. Use
 - [Passkeys](/docs/features/passkeys): Unlock your wallet with the same biometric or device passcode you already use, keeping access seamless and secure.
 - [Referrals](/docs/features/referrals): Share Send with friends or partners and earn fee credits when they become active members of the network.
 - [Rewards](/docs/features/rewards): Track how everyday activity, transfers, and community growth translate into ongoing rewards.
-- [Send Checks](/docs/features/send-checks): Send crypto to anyone using a shareable link — no wallet address needed.
+- [Send Links](/docs/features/send-checks): Send crypto to anyone using a shareable link — no wallet address needed.
 - [Sendtags](/docs/features/sendtags): Claim human-readable usernames so people can pay you without memorizing wallet addresses.
 - [Savings](/docs/features/savings): Put idle USDC to work in a liquid vault that yields interest while letting you withdraw anytime.
 - [Invest](/docs/features/invest): Review trading fees and mechanics before swapping assets inside the Send app.


### PR DESCRIPTION
Updates all references to use the correct "Send Links" product terminology throughout the documentation.

Closes #8

Generated with [Claude Code](https://claude.ai/code)